### PR TITLE
fix xAvgCharWidth

### DIFF
--- a/scripts/fix-xavgcharwidth.sh
+++ b/scripts/fix-xavgcharwidth.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+fix () {
+  filename=$1
+
+  ttx -o "$filename.ttx" -t "OS/2" $filename
+  sed -i "s/xAvgCharWidth value=\"[0-9]\+\"/xAvgCharWidth value=\"500\"/" "$filename.ttx"
+  ttx -o ${filename/.ttf/.after.ttf} -m $filename "$filename.ttx"
+  rm "$filename.ttx"
+}
+
+fix ./sarasa/sarasa-mono-sc-nerd-bold.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-bolditalic.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-extralight.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-extralightitalic.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-italic.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-light.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-lightitalic.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-regular.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-semibold.ttf
+fix ./sarasa/sarasa-mono-sc-nerd-semibolditalic.ttf

--- a/scripts/fix-xavgcharwidth.sh
+++ b/scripts/fix-xavgcharwidth.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
 
 fix () {
-  filename=$1
+  original_font=$1
+  patched_font=$2
 
-  ttx -o "$filename.ttx" -t "OS/2" $filename
-  sed -i "s/xAvgCharWidth value=\"[0-9]\+\"/xAvgCharWidth value=\"500\"/" "$filename.ttx"
-  ttx -o ${filename/.ttf/.after.ttf} -m $filename "$filename.ttx"
-  rm "$filename.ttx"
+  ttx -o "$original_font.ttx" -t "OS/2" $original_font
+  ttx -o "$patched_font.ttx" -t "OS/2" $patched_font
+
+  original_x_avg_char_width="$(grep xAvgCharWidth "$original_font.ttx" | cut -d '"' -f 2)"
+  echo original xAvgCharWidth is $original_x_avg_char_width
+
+  sed -i "s/xAvgCharWidth value=\"[0-9]\+\"/xAvgCharWidth value=\"${original_x_avg_char_width}\"/g" \
+    "$patched_font.ttx"
+
+  ttx -o ${patched_font/.ttf/.after.ttf} -m $patched_font "$patched_font.ttx"
+
+  rm "$original_font.ttx" "$patched_font.ttx"
 }
 
-fix ./sarasa/sarasa-mono-sc-nerd-bold.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-bolditalic.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-extralight.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-extralightitalic.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-italic.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-light.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-lightitalic.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-regular.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-semibold.ttf
-fix ./sarasa/sarasa-mono-sc-nerd-semibolditalic.ttf
+fix ./sarasa/sarasa-mono-sc-bold.ttf             ./sarasa/sarasa-mono-sc-nerd-bold.ttf
+fix ./sarasa/sarasa-mono-sc-bolditalic.ttf       ./sarasa/sarasa-mono-sc-nerd-bolditalic.ttf
+fix ./sarasa/sarasa-mono-sc-extralight.ttf       ./sarasa/sarasa-mono-sc-nerd-extralight.ttf
+fix ./sarasa/sarasa-mono-sc-extralightitalic.ttf ./sarasa/sarasa-mono-sc-nerd-extralightitalic.ttf
+fix ./sarasa/sarasa-mono-sc-italic.ttf           ./sarasa/sarasa-mono-sc-nerd-italic.ttf
+fix ./sarasa/sarasa-mono-sc-light.ttf            ./sarasa/sarasa-mono-sc-nerd-light.ttf
+fix ./sarasa/sarasa-mono-sc-lightitalic.ttf      ./sarasa/sarasa-mono-sc-nerd-lightitalic.ttf
+fix ./sarasa/sarasa-mono-sc-regular.ttf          ./sarasa/sarasa-mono-sc-nerd-regular.ttf
+fix ./sarasa/sarasa-mono-sc-semibold.ttf         ./sarasa/sarasa-mono-sc-nerd-semibold.ttf
+fix ./sarasa/sarasa-mono-sc-semibolditalic.ttf   ./sarasa/sarasa-mono-sc-nerd-semibolditalic.ttf


### PR DESCRIPTION
解決問題 #8

腳本是參考了 https://github.com/laishulu/Sarasa-Mono-SC-Nerd/issues/8#issuecomment-975682017 所撰寫

主要是利用了 fonttools 所提供的 ttx 指令工具，將字體中的 xAvgCharWidth 值設為 500，便能解決字體寬度顯示異常的問題